### PR TITLE
FIX setup warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     install_requires=requirements,
     license="MIT license",
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/x-rst',
     include_package_data=True,
     keywords='pica',
     name='pica',


### PR DESCRIPTION
twine warns that "`long_description_content_type` missing.  defaulting to `text/x-rst`. "
Better set this explicitely.