### PR TITLE
MNT update badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,24 +4,23 @@ pheno-trex
 
 
 .. image:: https://img.shields.io/pypi/v/phenotrex.svg
-        :target: https://pypi.python.org/pypi/phenotrex
+    :target: https://pypi.python.org/pypi/phenotrex
 
-.. image:: https://travis-ci.com/univieCUBE/PICA2.svg?branch=master
-    :target: https://travis-ci.com/univieCUBE/PICA2
+.. image:: https://travis-ci.com/univieCUBE/phenotrex.svg?branch=master
+    :target: https://travis-ci.com/univieCUBE/phenotrex
 
-.. image:: https://codecov.io/gh/univieCUBE/PICA2/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/univieCUBE/PICA2
+.. image:: https://codecov.io/gh/univieCUBE/phenotrex/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/univieCUBE/phenotrex
 
 .. image:: https://ci.appveyor.com/api/projects/status/iursmhw1wocfgpua?svg=true
-  :target: https://ci.appveyor.com/project/VarIr/pica2
+    :target: https://ci.appveyor.com/project/VarIr/phenotrex
 
-.. image:: https://readthedocs.org/projects/pica2-test/badge/?version=latest
-        :target: https://pica2_test.readthedocs.io/en/latest/?badge=latest
-        :alt: Documentation Status
+.. image:: https://readthedocs.org/projects/phenotrex/badge/?version=latest
+    :target: https://phenotrex.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
 
 
 Microbial Phenotype Prediction, re-implemented with Python 3.7 and scikit-learn
 
 * Supported platforms: Linux, MacOS, Windows
 * Free software: MIT license
-


### PR DESCRIPTION
Update the URLs of badges in the readme for the new package name `phenotrex` instead of `PICA2`. 