### PR TITLE
MNT update travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
-lanuage: python
+language: python
 
 python:
   - '3.7'
+  - '3.8'
 
-matrix:
+jobs:
+  allow_failures:
+    - os: osx
   include:
     - os: linux
       dist: xenial
-      sudo: false
     - os: osx
       # osx_image: xcode10.2
-      sudo: true
 
 env:
   global:


### PR DESCRIPTION
- Additional test on Python 3.8
- Fix config issues due to warnings at https://travis-ci.com/univieCUBE/phenotrex/jobs/281452673/config
- Temporarily allow to fail macos jobs on Travis (all macos Python jobs currently fail on travis)