### PR TITLE
FIX Travis/Linux/AVX512 errors from PyTorch/MKLDNN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ jobs:
       python: '3.8'
     # See https://blog.travis-ci.com/2019-08-07-extensive-python-testing-on-travis-ci
     # for macos config peculiarities.
-    - name: Python 3.7 on MacOS X (xcode 10.3)
+    - name: Python 3.7 on MacOS X (xcode 10.2)
       os: osx
       language: shell
-      osx_image: xcode10.3
+      osx_image: xcode10.2
       python: '3.7'
     - name: Python 3.8 on MacOS X (xcode 11.3)
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ jobs:
     - name: Python 3.7 on MacOS X (xcode 10.3)
       os: osx
       language: shell
-      osx_image: xcode10.3  # Python 3.7
-    - name: Python 3.7 on MacOS X (xcode 11.3)
+      osx_image: xcode10.3
+      python: '3.7'
+    - name: Python 3.8 on MacOS X (xcode 11.3)
       os: osx
       language: shell
-      osx_image: xcode11.3  # Python 3.7.5
+      osx_image: xcode11.3
+      python: '3.8'
 
 env:
   global:

--- a/requirements/win.txt
+++ b/requirements/win.txt
@@ -1,1 +1,1 @@
-torch>=1.2.0+cpu
+'torch>=1.2.0'+cpu

--- a/requirements/win.txt
+++ b/requirements/win.txt
@@ -1,1 +1,1 @@
-'torch>=1.2.0'+cpu
+torch+cpu

--- a/requirements/win.txt
+++ b/requirements/win.txt
@@ -1,1 +1,1 @@
-torch+cpu
+torch==1.5.0+cpu

--- a/travis/install-pip.sh
+++ b/travis/install-pip.sh
@@ -2,7 +2,23 @@
 
 set -e
 
-echo "pip installing required python packages"
-pip install -r requirements/dev.txt
+# Alternative to "conda init bash"
+source "$HOME/miniconda/etc/profile.d/conda.sh"
+
+conda activate test
+hash -r
+
+# Work-around for a bug in PyTorch/MKLDNN on Linux and AVX512 systems:
+# Fetch the pytorch-nightly, until the official release.
+if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
+  echo "install and upgrade PyTorch nightly"
+  conda install --yes pytorch cpuonly -c pytorch-nightly
+  echo "pip installing required python packages"
+  pip install -r requirements/dev.txt
+  python -c "import torch; print(f'PyTorch version = {torch.__version__}')"
+elif [[ "$TRAVIS_OS_NAME" == 'osx' ]]; then
+  echo "pip installing required python packages"
+  pip install -r requirements/dev.txt
+fi
 
 python --version


### PR DESCRIPTION
PyTorch with MKL-DNN errors on AVX-512 capables machines on Linux,
which hits our Travis build via the deepnog dependency.
(`Code is too big` errors, see also https://github.com/univieCUBE/deepnog/issues/6 ).

This is fixed in newer PyTorch versions that build upon Intel's new DNNL
library instead of MKL-DNN. Apparently, the fix did not make it into PyTorch 1.5,
so we install the 1.6-nightly on Travis/Linux as a work-around.