### PR TITLE
Quality of Life Improvements and Minor Fixes

### DIFF
--- a/phenotrex/__init__.py
+++ b/phenotrex/__init__.py
@@ -4,5 +4,5 @@
 
 __author__ = """Lukas Lüftinger"""
 __email__ = 'lukas.lueftinger@outlook.com'
-__version__ = '0.5.1'
+__version__ = '0.6.0'
 __all__ = ['io', 'ml', 'util', 'transforms']

--- a/phenotrex/cli/cccv.py
+++ b/phenotrex/cli/cccv.py
@@ -23,9 +23,9 @@ def cccv_options(f):
     """CCCV-specific CLI options."""
     f = click.option('--out', type=click.Path(), required=True,
                      help='Output file path for CCCV results.')(f)
-    f = click.option('--conta-steps', type=int, default=20,
+    f = click.option('--conta_steps', type=int, default=20,
                      help='Number of equidistant contamination levels to resample to.')(f)
-    f = click.option('--comple-steps', type=int, default=20,
+    f = click.option('--comple_steps', type=int, default=20,
                      help='Number of equidistant completeness levels to resample to.')(f)
     return f
 

--- a/phenotrex/cli/compute_genotype.py
+++ b/phenotrex/cli/compute_genotype.py
@@ -1,5 +1,7 @@
 import click
 
+from phenotrex.cli.generic_opt import common_deepnog_options
+
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]),
                short_help="Transform FASTA files into a genotype file.")
@@ -9,7 +11,8 @@ import click
 @click.option('--threads', type=int, required=False,
               help='Number of parallel threads (default is the number available cores)')
 @click.option('--verb', is_flag=True)
-def compute_genotype(input, out, threads=None, verb=True):
+@common_deepnog_options
+def compute_genotype(input, out, deepnog_threshold, threads=None, verb=True):
     """
     Create a genotype file suitable for learning and inference with `phenotrex`.
     Given a set of (possibly gzipped) DNA or protein FASTA files,
@@ -19,5 +22,7 @@ def compute_genotype(input, out, threads=None, verb=True):
     from phenotrex.transforms import fastas_to_grs
 
     write_genotype_file(
-        genotypes=fastas_to_grs(input, verb=verb, n_threads=threads), output_file=out
+        genotypes=fastas_to_grs(
+            input, confidence_threshold=deepnog_threshold, verb=verb, n_threads=threads
+        ), output_file=out
     )

--- a/phenotrex/cli/compute_genotype.py
+++ b/phenotrex/cli/compute_genotype.py
@@ -6,10 +6,10 @@ import click
 @click.argument('input', required=True, type=click.Path(exists=True), nargs=-1)
 @click.option('--out', type=click.Path(exists=False),
               required=True, help='Path of output genotype file.')
-@click.option('--n_threads', type=int, required=False,
+@click.option('--threads', type=int, required=False,
               help='Number of parallel threads (default is the number available cores)')
 @click.option('--verb', is_flag=True)
-def compute_genotype(input, out, n_threads=None, verb=True):
+def compute_genotype(input, out, threads=None, verb=True):
     """
     Create a genotype file suitable for learning and inference with `phenotrex`.
     Given a set of (possibly gzipped) DNA or protein FASTA files,
@@ -19,5 +19,5 @@ def compute_genotype(input, out, n_threads=None, verb=True):
     from phenotrex.transforms import fastas_to_grs
 
     write_genotype_file(
-        genotypes=fastas_to_grs(input, verb=verb, n_threads=n_threads), output_file=out
+        genotypes=fastas_to_grs(input, verb=verb, n_threads=threads), output_file=out
     )

--- a/phenotrex/cli/generic_opt.py
+++ b/phenotrex/cli/generic_opt.py
@@ -34,3 +34,16 @@ def common_cv_options(f):
     f = click.option('--phenotype', type=click.Path(exists=True),
                      required=True, help='Phenotype file path.')(f)
     return f
+
+
+def common_deepnog_options(f):
+    """Options added to commands which make use of deepnog."""
+    f = click.option(
+        '--deepnog_threshold',
+        type=click.FloatRange(min=0.0, max=1.0),
+        default=None,
+        help='The confidence cutoff for feature creation directly from FASTA files.'
+             ' Only features identfied in the genome with a confidence greater than'
+             ' this are considered.'
+    )(f)
+    return f

--- a/phenotrex/cli/predict.py
+++ b/phenotrex/cli/predict.py
@@ -1,5 +1,7 @@
 import click
 
+from phenotrex.cli.generic_opt import common_deepnog_options
+
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]),
                short_help="Prediction of phenotypes with classifier")
@@ -22,6 +24,7 @@ import click
               help='The nsamples parameter of SHAP. Only used by models '
                    'which utilize a `shap.KernelExplainer` (e.g. TrexSVM).')
 @click.option('--verb', is_flag=True)
+@common_deepnog_options
 def predict(*args, **kwargs):
     """
     Predict phenotype from a set of (possibly gzipped) DNA or protein FASTA files

--- a/phenotrex/ml/prediction.py
+++ b/phenotrex/ml/prediction.py
@@ -20,7 +20,8 @@ def predict(
     out_explain_summary=None,
     shap_n_samples=None,
     n_max_explained_features=None,
-    verb=False
+    deepnog_threshold=None,
+    verb=False,
 ):
     """
     Predict phenotype from a set of (possibly gzipped) DNA or protein FASTA files
@@ -38,18 +39,24 @@ def predict(
     :param fasta_files: An iterable of fasta file paths
     :param genotype: A genotype file path
     :param classifier: A pickled classifier file path
+    :param min_proba: the threshold of confidence of the phenotrex prediction below which the
+                      prediction will be masked by 'N/A'.
     :param out_explain_per_sample: Where to save the most influential features by SHAP for each
                                    predicted sample.
     :param out_explain_summary: Where to save the SHAP summary of the predictions.
     :param shap_n_samples: The n_samples parameter -
                            only used by models which incorporate a `shap.KernelExplainer`.
     :param n_max_explained_features: How many of the most influential features by SHAP to consider.
+    :param deepnog_threshold: The threshold of confidence above which to keep an output of
+                              deepnog annotation.
     :param verb: Whether to show progress of fasta file annotation.
     """
     if not len(fasta_files) and genotype is None:
         raise RuntimeError('Must supply FASTA file(s) and/or single genotype file for prediction.')
     if len(fasta_files):
-        grs_from_fasta = fastas_to_grs(fasta_files, n_threads=None, verb=verb)
+        grs_from_fasta = fastas_to_grs(
+            fasta_files, confidence_threshold=deepnog_threshold, n_threads=None, verb=verb
+        )
     else:
         grs_from_fasta = []
 

--- a/phenotrex/ml/prediction.py
+++ b/phenotrex/ml/prediction.py
@@ -39,16 +39,16 @@ def predict(
     :param fasta_files: An iterable of fasta file paths
     :param genotype: A genotype file path
     :param classifier: A pickled classifier file path
-    :param min_proba: the threshold of confidence of the phenotrex prediction below which the
-                      prediction will be masked by 'N/A'.
+    :param min_proba: Confidence threshold of the phenotrex prediction below which
+                      predictions will be masked by 'N/A'.
     :param out_explain_per_sample: Where to save the most influential features by SHAP for each
                                    predicted sample.
     :param out_explain_summary: Where to save the SHAP summary of the predictions.
     :param shap_n_samples: The n_samples parameter -
                            only used by models which incorporate a `shap.KernelExplainer`.
     :param n_max_explained_features: How many of the most influential features by SHAP to consider.
-    :param deepnog_threshold: The threshold of confidence above which to keep an output of
-                              deepnog annotation.
+    :param deepnog_threshold: Confidence threshold of deepnog annotations below which annotations
+                              will be discarded.
     :param verb: Whether to show progress of fasta file annotation.
     """
     if not len(fasta_files) and genotype is None:

--- a/phenotrex/transforms/annotation.py
+++ b/phenotrex/transforms/annotation.py
@@ -67,8 +67,8 @@ def fastas_to_grs(
 
     :param fasta_files: a list of DNA and/or protein FASTA files to be converted into
                         GenotypeRecords.
-    :param confidence_threshold: The threshold of confidence above which to keep an output of
-                                 deepnog annotation.
+    :param confidence_threshold: Confidence threshold of deepnog annotations below which annotations
+                                 will be discarded.
     :param verb: Whether to display progress of annotation with tqdm.
     :param n_threads: Number of parallel threads. Default, use all available CPU cores.
     :returns: A list of GenotypeRecords corresponding with supplied FASTA files.
@@ -98,27 +98,20 @@ def fasta_to_gr(
     GenotypeRecord (output of deepnog) of the file.
 
     :param fasta_file: A DNA or protein fasta file to be converted into GenotypeRecord.
-    :param confidence_threshold: The threshold of confidence above which to keep an output of
-                                 deepnog annotation.
+    :param confidence_threshold: Confidence threshold of deepnog annotations below which annotations
+                                 will be discarded.
     :param verb: Whether to display progress of annotation with tqdm.
     :returns: A single GenotypeRecord representing the sample.
     """
     fname = Path(str(fasta_file)).name
     seqtype, seqs = load_fasta_file(fasta_file)
-    if seqtype == 'protein':
-        return annotate_with_deepnog(
-            fname,
-            seqs,
-            confidence_threshold=confidence_threshold,
-            verb=verb
-        )
-    else:
-        return annotate_with_deepnog(
-            fname,
-            call_proteins(seqs),
-            confidence_threshold=confidence_threshold,
-            verb=verb
-        )
+    seqs = seqs if seqtype == 'protein' else call_proteins(seqs)
+    return annotate_with_deepnog(
+        fname,
+        seqs,
+        confidence_threshold=confidence_threshold,
+        verb=verb
+    )
 
 
 def call_proteins(seqs: List[SeqRecord]) -> List[SeqRecord]:
@@ -151,13 +144,14 @@ def annotate_with_deepnog(
     verb: bool = True
 ) -> GenotypeRecord:
     """
-    Perform calling of clusters on a list of SeqRecords belonging to a sample using deepnog.
+    Assign proteins belonging to a sample to orthologous groups using deepnog.
 
     :param identifier: The name associated with the sample.
     :param protein_list: A list of SeqRecords containing protein sequences.
     :param database: Orthologous group/family database to use.
     :param tax_level: The NCBI taxon ID of the taxonomic level to use from the given database.
-    :param confidence_threshold: The confidence threshold above which to report a hit.
+    :param confidence_threshold: Confidence threshold of deepnog annotations below which annotations
+                                 will be discarded.
     :param verb: Whether to print verbose progress messages.
     :returns: a GenotypeRecord suitable for use with phenotrex.
     """


### PR DESCRIPTION
While writing the usage documentation, I stumbled across several minor inconsistencies and desirable behaviours which this PR fixes and implements. Please excuse the multi-issue PR, none of these are worth their own.

- Several flags were inconsistent across the CLI, this fixes that.
- When trying to predict many samples with significant parallelization, I observed that the tqdm bar sometimes gets stuck. This fixes that, by using `tqdm.contrib.concurrent` instead of using `concurrent.futures` manually (why that fixes it, I don't know. Is supposed to to the same thing...)
- The standard weights.tsv file output during phenotrex training did not have the same EggNOG5 feature annotations as the output of feature explanation with SHAP. This useful introspection capability has been added.
- The confidence cutoff of `deepnog` feature extraction was not settable. This flag has been added to `phenotrex predict` and `phenotrex compute-genotype`.